### PR TITLE
Fix recursive cleanup issue

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -51,9 +51,10 @@ class CommandShell
     self.platform ||= ""
     self.arch     ||= ""
     self.max_threads = 1
+    @cleanup = false
     datastore = opts[:datastore]
     if datastore && !datastore["CommandShellCleanupCommand"].blank?
-      @cleanup_command = opts[:datastore]["CommandShellCleanupCommand"]
+      @cleanup_command = datastore["CommandShellCleanupCommand"]
     end
     super
   end
@@ -163,6 +164,9 @@ class CommandShell
   # Closes the shell.
   #
   def cleanup
+    return if @cleanup
+
+    @cleanup = true
     if rstream
       if !@cleanup_command.blank?
         # this is a best effort, since the session is possibly already dead


### PR DESCRIPTION
This was just a simple fix for the issue I was observing while testing the PR. I'm uncertain the threading surrounding `CommandShell`, however, if there is any multithreaded access to this class the problem should be resolved using a semaphore. If you have a cleaner solution please close this PR.