### PR TITLE
Fix #9596

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -42,14 +42,14 @@ module Auxiliary::DRDoS
       this_proof += ' and '
 
       # compute bandwidth amplification
-      total_size = responses.map(&:size).reduce(:+)
-      bandwidth_amplification = total_size - request.size
+      total_size = responses.map(&:num_bytes).reduce(:+)
+      bandwidth_amplification = total_size - request.num_bytes
       if bandwidth_amplification > 0
         vulnerable = true
-        if request.size == 0
+        if request.num_bytes == 0
           multiplier = total_size
         else
-          multiplier = total_size / request.size
+          multiplier = total_size / request.num_bytes
         end
         this_proof += "a #{multiplier}x, #{bandwidth_amplification}-byte bandwidth amplification"
       else

--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -42,14 +42,14 @@ module Auxiliary::DRDoS
       this_proof += ' and '
 
       # compute bandwidth amplification
-      total_size = responses.map(&:num_bytes).reduce(:+)
-      bandwidth_amplification = total_size - request.num_bytes
+      total_size = responses.map(&:size).reduce(:+)
+      bandwidth_amplification = total_size - request.size
       if bandwidth_amplification > 0
         vulnerable = true
-        if request.num_bytes == 0
+        if request.size == 0
           multiplier = total_size
         else
-          multiplier = total_size / request.num_bytes
+          multiplier = total_size / request.size
         end
         this_proof += "a #{multiplier}x, #{bandwidth_amplification}-byte bandwidth amplification"
       else

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -17,7 +17,7 @@ module NTP
   #   http://tools.ietf.org/html/rfc1305#appendix-D
   #   http://tools.ietf.org/html/rfc5905#page-19
   class NTPGeneric < BinData::Record
-    alias :size :num_bytes
+    alias size num_bytes
     #    0                   1                   2                   3
     #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -36,7 +36,7 @@ module NTP
   # An NTP control message.  Control messages are only specified for NTP
   # versions 2-4, but this is a fuzzer so why not try them all...
   class NTPControl < BinData::Record
-    alias :size :num_bytes
+    alias size num_bytes
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -66,7 +66,7 @@ module NTP
   # An NTP "private" message.  Private messages are only specified for NTP
   # versions 2-4, but this is a fuzzer so why not try them all...
   class NTPPrivate < BinData::Record
-    alias :size :num_bytes
+    alias size num_bytes
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -99,7 +99,7 @@ module NTP
   end
 
   class NTPSymmetric < BinData::Record
-    alias :size :num_bytes
+    alias size num_bytes
     endian :big
     bit2   :li
     bit3   :version, initial_value: 3

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -17,6 +17,7 @@ module NTP
   #   http://tools.ietf.org/html/rfc1305#appendix-D
   #   http://tools.ietf.org/html/rfc5905#page-19
   class NTPGeneric < BinData::Record
+    alias :size :num_bytes
     #    0                   1                   2                   3
     #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -35,6 +36,7 @@ module NTP
   # An NTP control message.  Control messages are only specified for NTP
   # versions 2-4, but this is a fuzzer so why not try them all...
   class NTPControl < BinData::Record
+    alias :size :num_bytes
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -64,6 +66,7 @@ module NTP
   # An NTP "private" message.  Private messages are only specified for NTP
   # versions 2-4, but this is a fuzzer so why not try them all...
   class NTPPrivate < BinData::Record
+    alias :size :num_bytes
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -96,6 +99,7 @@ module NTP
   end
 
   class NTPSymmetric < BinData::Record
+    alias :size :num_bytes
     endian :big
     bit2   :li
     bit3   :version, initial_value: 3


### PR DESCRIPTION
The DRDOS mixin operates on strings.  This fixes https://github.com/rapid7/metasploit-framework/pull/9596/ to account for this. 