### PR TITLE
Fix thread exception reporting for Ruby 2.3.8

### DIFF
--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,7 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Thread.respond_to?(:report_on_exception=)
+    if Thread.method_defined?(:report_on_exception=)
       Thread.report_on_exception = false
     end
   end

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,7 +59,7 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Thread.respond_to?(:report_on_exception)
+    if Thread.respond_to?(:report_on_exception=)
       Thread.report_on_exception = false
     end
   end

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -59,8 +59,8 @@ class ThreadManager < Array
 
     # XXX: Preserve Ruby < 2.5 thread exception reporting behavior
     # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception
-    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
-      Thread.report_on_exception = false if Thread.report_on_exception
+    if Thread.respond_to?(:report_on_exception)
+      Thread.report_on_exception = false
     end
   end
 


### PR DESCRIPTION
`Thread::report_on_exception` doesn't exist. The error was swallowed in our tests.

```
/Users/wvu/metasploit-framework/lib/msf/core/thread_manager.rb:63:in `initialize': undefined method `report_on_exception=' for Thread:Class (NoMethodError)
	from /Users/wvu/metasploit-framework/lib/msf/core/framework.rb:226:in `new'
	from /Users/wvu/metasploit-framework/lib/msf/core/framework.rb:226:in `block in threads'
	from /Users/wvu/.rbenv/versions/2.3.8/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
	from /Users/wvu/metasploit-framework/lib/msf/core/framework.rb:225:in `threads'
	from /Users/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:165:in `initialize'
	from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
	from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'
	from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
	from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
	from ./msfconsole:49:in `<main>'
```

https://github.com/rapid7/metasploit-framework/pull/10900