### PR TITLE
Fix RPC support by raising instead of returning when checking for check

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -116,7 +116,10 @@ module Auxiliary
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
-    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+    unless mod.has_check?
+      # Bail out early if the module doesn't have check
+      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+    end
 
     # Validate the option container state so that options will
     # be normalized

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -184,7 +184,10 @@ module Exploit
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
-    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+    unless mod.has_check?
+      # Bail out early if the module doesn't have check
+      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+    end
 
     # Validate the option container state so that options will
     # be normalized


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/pull/13873/files#r457575263 (https://github.com/rapid7/metasploit-framework/pull/13873).

```
>> rpc.call('module.check', 'auxiliary', 'auxiliary/scanner/http/http_put', {})
Traceback (most recent call last):
        7: from ./msfrpc:92:in `<main>'
        6: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
        5: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
        4: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
        3: from (irb):1:in `<main>'
        2: from /rapid7/metasploit-framework/lib/msf/core/rpc/v10/client.rb:105:in `call'
        1: from /rapid7/metasploit-framework/lib/msf/core/rpc/v10/client.rb:158:in `send_rpc_request'
Msf::RPC::ServerException (Msf::ValidationError This module does not support check. ["lib/msf/base/simple/auxiliary.rb:121:in `check_simple'", "lib/msf/core/rpc/v10/rpc_module.rb:769:in `_check_auxiliary'", "lib/msf/core/rpc/v10/rpc_module.rb:518:in `rpc_check'", "lib/msf/core/rpc/v10/service.rb:155:in `block in process'", "lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'", "lib/ruby/2.6.0/timeout.rb:33:in `block in catch'", "lib/ruby/2.6.0/timeout.rb:33:in `catch'", "lib/ruby/2.6.0/timeout.rb:33:in `catch'", "lib/ruby/2.6.0/timeout.rb:108:in `timeout'", "lib/msf/core/rpc/v10/service.rb:155:in `process'", "lib/msf/core/rpc/v10/service.rb:93:in `on_request_uri'", "lib/msf/core/rpc/v10/service.rb:74:in `block in start'", "lib/rex/proto/http/handler/proc.rb:38:in `on_request'", "lib/rex/proto/http/server.rb:368:in `dispatch_request'", "lib/rex/proto/http/server.rb:302:in `on_client_data'", "lib/rex/proto/http/server.rb:161:in `block in start'", "lib/rex/io/stream_server.rb:48:in `on_client_data'", "lib/rex/io/stream_server.rb:199:in `block in monitor_clients'", "lib/rex/io/stream_server.rb:197:in `each'", "lib/rex/io/stream_server.rb:197:in `monitor_clients'", "lib/rex/io/stream_server.rb:73:in `block in start'", "lib/rex/thread_factory.rb:22:in `block in spawn'", "lib/msf/core/thread_manager.rb:106:in `block in spawn'"])
>> rpc.call('module.check', 'auxiliary', 'auxiliary/scanner/http/http_put', 'RHOSTS' => '127.0.0.1')
Traceback (most recent call last):
        8: from ./msfrpc:92:in `<main>'
        7: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
        6: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
        5: from /rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
        4: from (irb):1:in `<main>'
        3: from (irb):2:in `rescue in <main>'
        2: from /rapid7/metasploit-framework/lib/msf/core/rpc/v10/client.rb:105:in `call'
        1: from /rapid7/metasploit-framework/lib/msf/core/rpc/v10/client.rb:158:in `send_rpc_request'
Msf::RPC::ServerException (Msf::ValidationError This module does not support check. ["lib/msf/base/simple/auxiliary.rb:121:in `check_simple'", "lib/msf/core/rpc/v10/rpc_module.rb:769:in `_check_auxiliary'", "lib/msf/core/rpc/v10/rpc_module.rb:518:in `rpc_check'", "lib/msf/core/rpc/v10/service.rb:155:in `block in process'", "lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'", "lib/ruby/2.6.0/timeout.rb:33:in `block in catch'", "lib/ruby/2.6.0/timeout.rb:33:in `catch'", "lib/ruby/2.6.0/timeout.rb:33:in `catch'", "lib/ruby/2.6.0/timeout.rb:108:in `timeout'", "lib/msf/core/rpc/v10/service.rb:155:in `process'", "lib/msf/core/rpc/v10/service.rb:93:in `on_request_uri'", "lib/msf/core/rpc/v10/service.rb:74:in `block in start'", "lib/rex/proto/http/handler/proc.rb:38:in `on_request'", "lib/rex/proto/http/server.rb:368:in `dispatch_request'", "lib/rex/proto/http/server.rb:302:in `on_client_data'", "lib/rex/proto/http/server.rb:161:in `block in start'", "lib/rex/io/stream_server.rb:48:in `on_client_data'", "lib/rex/io/stream_server.rb:199:in `block in monitor_clients'", "lib/rex/io/stream_server.rb:197:in `each'", "lib/rex/io/stream_server.rb:197:in `monitor_clients'", "lib/rex/io/stream_server.rb:73:in `block in start'", "lib/rex/thread_factory.rb:22:in `block in spawn'", "lib/msf/core/thread_manager.rb:106:in `block in spawn'"])
>>
```

The side effect is that it will always bail if there's no `check`. It won't run a job. This may be problematic. Also, it's relying on an exception instead of a return value in the command dispatcher.

It may be better to close the original PR if we're not satisfied with the changes.