### PR TITLE
Update json rpc process request error handling

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -118,7 +118,7 @@ module Auxiliary
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -186,7 +186,7 @@ module Exploit
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/core/rpc/json/dispatcher.rb
+++ b/lib/msf/core/rpc/json/dispatcher.rb
@@ -111,6 +111,10 @@ module Msf::RPC::JSON
         end
 
         response
+      rescue Msf::OptionValidateError => e
+        raise InvalidParams.new(data: { options: e.options, message: e.message })
+      rescue ::NoMethodError => e
+        raise MethodNotFound.new(e.name, data: { method: e.name, message: e.message })
       rescue ArgumentError
         raise InvalidParams.new
       rescue Msf::RPC::Exception => e


### PR DESCRIPTION
Fixing additional edge cases with the json rpc process request error handling

## Verification

Within a module:

![image](https://user-images.githubusercontent.com/60357436/88088034-b53b3f00-cb81-11ea-9564-c07c7535ccbc.png)

Within the RPC service calling a module without a check method:

![image](https://user-images.githubusercontent.com/60357436/88087994-a8b6e680-cb81-11ea-9cc3-e4b3389f97c7.png)

Within the RPC Service calling a module that fails validation

![image](https://user-images.githubusercontent.com/60357436/88088004-abb1d700-cb81-11ea-839d-f23c67d987d8.png)

Calling a module without a check method within within `msfrpc`

![image](https://user-images.githubusercontent.com/60357436/88088011-aeacc780-cb81-11ea-9916-30cdc0a6b898.png)
